### PR TITLE
Added more test cases #2

### DIFF
--- a/routes/route.js
+++ b/routes/route.js
@@ -46,7 +46,10 @@ module.exports = function (app){
     * @apiParam {String}
     */
     app.get('/api/status/:id', function(req, res){
-        hostid = _services[req.params.id];
-        res.json(_services);
+        var service = _services.filter( function (s){
+            return s.id == req.params.id;
+        })[0];
+
+        res.json(service);
     });
 }

--- a/test/server.js
+++ b/test/server.js
@@ -17,4 +17,67 @@ describe('Testing express server', function(){
             .get('/api/no/endpoint')
             .expect(404, done);
     });
+    it('Returns empty array for api/status', function testPath(done){
+        request(server)
+            .get('/api/status')
+            .expect(200, [], done);
+    });
+    it('Returns empty array if no service added', function testPath(done){
+        request(server)
+            .get('/api/status')
+            .expect(200, [], done);
+    });
+    it('Returns 404 if posting service without serviceName', function testPath(done){
+        request(server)
+            .post('/api/status')
+            .send({ value: 'service value' })
+            .expect(400, 'Error 400: Post syntax incorrect.', done);
+    });
+    it('Returns 404 if posting service without value', function testPath(done){
+        request(server)
+            .post('/api/status')
+            .send({ serviceName: 'service name' })
+            .expect(400, 'Error 400: Post syntax incorrect.', done);
+    });
+    it('Returns true if service added', function testPath(done){
+        request(server)
+            .post('/api/status')
+            .send({ serviceName: 'service name', value: 'service value' })
+            .expect(200, 'true', done);
+    });
+    it('Returns added service after one was added', function testPath(done){
+        var checkRsp = function(res){
+            if (!('serviceName' in res.body[0])) throw new Error("missing serviceName key");
+            if (!('value' in res.body[0])) throw new Error("missing value key");
+        };
+
+        request(server)
+            .get('/api/status')
+            .expect(200)
+            .expect(checkRsp)
+            .end(done);
+    });
+    it('Returns added service when requesting it by id', function testPath(done){
+        var serviceId;
+        var getServiceId = function(res){
+            if (!('serviceName' in res.body[0])) throw new Error("missing serviceName key");
+            if (!('value' in res.body[0])) throw new Error("missing value key");
+            serviceId = res.body[0].id;
+        };
+        var checkRsp = function(res){
+            if (!('serviceName' in res.body)) throw new Error("missing serviceName key");
+            if (!('value' in res.body)) throw new Error("missing value key");
+        };
+
+        request(server)
+            .get('/api/status')
+            .expect(200)
+            .expect(getServiceId)
+            .end(function(){
+                request(server)
+                    .get('/api/status/' + serviceId)
+                    .expect(checkRsp)
+                    .end(done);
+            });
+    });
 })


### PR DESCRIPTION
Hi @BondAnthony,

I've added more test cases as issue #2 stated. I have also changed what `/api/status/:id` returns, as it returned the entire array of service, instead of just the service requested.